### PR TITLE
(1) Add a way to pause the physics simulation (2) Implement raycast (3) Fix applyImpulse() with wrong parameter order (4) Fix missing import (5) Fix linear and angular damping have no effect

### DIFF
--- a/Sources/armory/trait/physics/oimo/PhysicsConstraint.hx
+++ b/Sources/armory/trait/physics/oimo/PhysicsConstraint.hx
@@ -1,6 +1,7 @@
 package armory.trait.physics.oimo;
 
 #if arm_oimo
+import iron.Trait;
 
 class PhysicsConstraint extends Trait {
 

--- a/Sources/armory/trait/physics/oimo/PhysicsHook.hx
+++ b/Sources/armory/trait/physics/oimo/PhysicsHook.hx
@@ -1,6 +1,7 @@
 package armory.trait.physics.oimo;
 
 #if arm_oimo
+import iron.Trait;
 
 class PhysicsHook extends Trait {
 

--- a/Sources/armory/trait/physics/oimo/PhysicsWorld.hx
+++ b/Sources/armory/trait/physics/oimo/PhysicsWorld.hx
@@ -34,6 +34,7 @@ class PhysicsWorld extends Trait {
 	static inline var timeStep = 1 / 60;
 	static inline var fixedStep = 1 / 60;
 	public var hitPointWorld = new Vec4();
+	public var rayCastResult:oimo.dynamics.callback.RayCastClosest;
 	public var pause = false;
 	
 	public function new() {
@@ -49,6 +50,7 @@ class PhysicsWorld extends Trait {
 
 		rbMap = new Map();
 		active = this;
+		rayCastResult = new oimo.dynamics.callback.RayCastClosest();
 
 		// Ensure physics are updated first in the lateUpdate list
 		_lateUpdate = [lateUpdate];
@@ -103,7 +105,13 @@ class PhysicsWorld extends Trait {
 	}
 
 	public function rayCast(from:Vec4, to:Vec4):RigidBody {
-		return null;
+		rayCastResult.clear();
+		world.rayCast(new oimo.common.Vec3(from.x, from.y, from.z), new oimo.common.Vec3(to.x, to.y, to.z), rayCastResult);
+		if (rayCastResult.shape!= null) {
+			return cast (rayCastResult.shape._rigidBody.userData, RigidBody);
+		} else {
+			return null;
+		}
 	}
 
 	public function notifyOnPreUpdate(f:Void->Void) {

--- a/Sources/armory/trait/physics/oimo/PhysicsWorld.hx
+++ b/Sources/armory/trait/physics/oimo/PhysicsWorld.hx
@@ -34,7 +34,8 @@ class PhysicsWorld extends Trait {
 	static inline var timeStep = 1 / 60;
 	static inline var fixedStep = 1 / 60;
 	public var hitPointWorld = new Vec4();
-
+	public var pause = false;
+	
 	public function new() {
 		super();
 
@@ -87,9 +88,10 @@ class PhysicsWorld extends Trait {
 
 		if (preUpdates != null) for (f in preUpdates) f();
 
-		world.step(timeStep);
-
-		for (rb in rbMap) @:privateAccess rb.physicsUpdate();
+		if (!pause) {
+			world.step(timeStep);
+			for (rb in rbMap) @:privateAccess rb.physicsUpdate();
+		}
 
 		#if arm_debug
 		physTime = kha.Scheduler.realTime() - startTime;

--- a/Sources/armory/trait/physics/oimo/RigidBody.hx
+++ b/Sources/armory/trait/physics/oimo/RigidBody.hx
@@ -137,6 +137,7 @@ class RigidBody extends Trait {
 		q1.init(transform.rot.x, transform.rot.y, transform.rot.z, transform.rot.w);
 		body.setOrientation(q1);
 		body.addShape(new oimo.dynamics.rigidbody.Shape(shapeConfig));
+		body.userData = this;
 
 		id = nextId++;
 

--- a/Sources/armory/trait/physics/oimo/RigidBody.hx
+++ b/Sources/armory/trait/physics/oimo/RigidBody.hx
@@ -184,8 +184,8 @@ class RigidBody extends Trait {
 	public function applyImpulse(impulse:Vec4, loc:Vec4 = null) {
 		activate();
 		if (loc == null) loc = transform.loc;
-		v1.init(loc.x, loc.y, loc.z);
-		v2.init(impulse.x, impulse.y, impulse.z);
+		v1.init(impulse.x, impulse.y, impulse.z);
+		v2.init(loc.x, loc.y, loc.z);
 		body.applyImpulse(v1, v2);
 	}
 

--- a/Sources/armory/trait/physics/oimo/RigidBody.hx
+++ b/Sources/armory/trait/physics/oimo/RigidBody.hx
@@ -137,6 +137,8 @@ class RigidBody extends Trait {
 		q1.init(transform.rot.x, transform.rot.y, transform.rot.z, transform.rot.w);
 		body.setOrientation(q1);
 		body.addShape(new oimo.dynamics.rigidbody.Shape(shapeConfig));
+		body.setLinearDamping(this.linearDamping);
+		body.setAngularDamping(this.angularDamping);
 		body.userData = this;
 
 		id = nextId++;


### PR DESCRIPTION
(1) The way to pause is referring to the same method to pause the simulation in the the Oimo demo by saharan himself.
(The timestep is not allowed to be set to 0.0 since it will be used as divisor later.)
This method was tested by myself and it did work.
(2) Implement the rayCast function for PhysicsWorld.
(3) Fix a bug that calling applyImpulse() with wrong parameter order.
(4) Fix missing import 
(5) Fix a bug that linear damping and angular damping are ignored.