### PR TITLE
Implement getContacts() and getContactPairs()

### DIFF
--- a/Sources/armory/trait/physics/oimo/SoftBody.hx
+++ b/Sources/armory/trait/physics/oimo/SoftBody.hx
@@ -1,6 +1,7 @@
 package armory.trait.physics.oimo;
 
 #if arm_oimo
+import iron.Trait;
 
 class SoftBody extends Trait {
 


### PR DESCRIPTION
It is using the implementation method of the same functions in Bullet, to keep them align.
When I test this, I found that when one rigid body is rolling over a static plane, Bullet considers they are contacting (distance < 0), while Oimo doesn't (distance = 0). I consider this is engine difference.